### PR TITLE
Fix a small typo in build-pkgs

### DIFF
--- a/.travis/build-pkgs
+++ b/.travis/build-pkgs
@@ -93,7 +93,7 @@ done
 
 printf '\n----\n'
 if [ -n "$successful_pkgs" ]; then
-	print -s1 -c2 "Successfully build packages:$successful_pkgs\n"
+	print -s1 -c2 "Successfully built packages:$successful_pkgs\n"
 fi
 if [ -n "$failed_pkgs" ]; then
 	die "Failed to build packages:$failed_pkgs"


### PR DESCRIPTION
The tense of `build` was incorrect.